### PR TITLE
[4.2.x] Fix #reconnect! method and CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ matrix:
     - DB=mysql
     - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
     addons:
-      mysql: "5.6"
       apt:
         packages:
         - unixodbc
         - unixodbc-dev
         - libmyodbc
         - mysql-client
+    services:
+      - mysql
   - rvm: 2.3.6
     env:
     - DB=postgresql
@@ -31,13 +32,14 @@ matrix:
     - DB=mysql
     - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
     addons:
-      mysql: "5.6"
       apt:
         packages:
         - unixodbc
         - unixodbc-dev
         - libmyodbc
         - mysql-client
+    services:
+      - mysql
   - rvm: 2.4.3
     env:
     - DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - DB=mysql
     - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
     addons:
-      mysql: "5.5"
+      mysql: "5.6"
       apt:
         packages:
         - unixodbc
@@ -20,7 +20,7 @@ matrix:
     - DB=postgresql
     - CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;'
     addons:
-      postgresql: "9.1"
+      postgresql: "9.2"
       apt:
         packages:
         - unixodbc
@@ -31,7 +31,7 @@ matrix:
     - DB=mysql
     - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
     addons:
-      mysql: "5.5"
+      mysql: "5.6"
       apt:
         packages:
         - unixodbc
@@ -43,7 +43,7 @@ matrix:
     - DB=postgresql
     - CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;'
     addons:
-      postgresql: "9.1"
+      postgresql: "9.2"
       apt:
         packages:
         - unixodbc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 matrix:
   include:
-  - rvm: 2.3.1
+  - rvm: 2.3.6
     env:
     - DB=mysql
     - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
@@ -15,7 +15,30 @@ matrix:
         - unixodbc-dev
         - libmyodbc
         - mysql-client
-  - rvm: 2.3.1
+  - rvm: 2.3.6
+    env:
+    - DB=postgresql
+    - CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;'
+    addons:
+      postgresql: "9.1"
+      apt:
+        packages:
+        - unixodbc
+        - unixodbc-dev
+        - odbc-postgresql
+  - rvm: 2.4.3
+    env:
+    - DB=mysql
+    - CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;'
+    addons:
+      mysql: "5.5"
+      apt:
+        packages:
+        - unixodbc
+        - unixodbc-dev
+        - libmyodbc
+        - mysql-client
+  - rvm: 2.4.3
     env:
     - DB=postgresql
     - CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - unixodbc
         - unixodbc-dev
         - libmyodbc
-        - mysql-client
+        - mysql-client-5.6
     services:
       - mysql
   - rvm: 2.3.6
@@ -37,7 +37,7 @@ matrix:
         - unixodbc
         - unixodbc-dev
         - libmyodbc
-        - mysql-client
+        - mysql-client-5.6
     services:
       - mysql
   - rvm: 2.4.3

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Next, configure your system with a PostgreSQL data source called `ODBCAdapterPostgreSQLTest` (you can alternatively set the environment variables `CONN_STR` or `DSN`). Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           end
 
         dbms = ::ODBCAdapter::DBMS.new(connection)
-        dbms.adapter_class.new(connection, logger, dbms)
+        dbms.adapter_class.new(connection, logger, dbms, config)
       end
 
       private
@@ -79,10 +79,11 @@ module ActiveRecord
 
       attr_reader :dbms
 
-      def initialize(connection, logger, dbms)
+      def initialize(connection, logger, dbms, options)
         super(connection, logger)
         @connection = connection
         @dbms       = dbms
+        @options    = options
         @visitor    = self.class::BindSubstitution.new(self)
       end
 
@@ -112,10 +113,10 @@ module ActiveRecord
       def reconnect!
         disconnect!
         @connection =
-          if options.key?(:dsn)
-            ODBC.connect(options[:dsn], options[:username], options[:password])
+          if @options.key?(:dsn)
+            ODBC.connect(@options[:dsn], @options[:username], @options[:password])
           else
-            ODBC::Database.new.drvconnect(options[:driver])
+            ODBC::Database.new.drvconnect(@options[:driver])
           end
         super
       end

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           end
 
         dbms = ::ODBCAdapter::DBMS.new(connection)
-        dbms.adapter_class.new(connection, logger, dbms, config)
+        dbms.adapter_class.new(connection, logger, dbms, options)
       end
 
       private

--- a/test/connections_test.rb
+++ b/test/connections_test.rb
@@ -39,5 +39,6 @@ class ConnectionsTest < Minitest::Test
     assert_equal true, @connection.active?
     @connection.reconnect!
     refute_equal @old_raw_connection, @connection.raw_connection
+    assert_equal true, @connection.active?
   end
 end

--- a/test/connections_test.rb
+++ b/test/connections_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+# Dummy class for this test
+class ConnectionsTestDummyActiveRecordModel < ActiveRecord::Base
+  self.abstract_class = true
+end
+
+# This test makes sure that all of the connection methods work properly
+class ConnectionsTest < Minitest::Test
+  def setup
+    @options = { adapter: 'odbc' }
+    @options[:conn_str] = ENV['CONN_STR'] if ENV['CONN_STR']
+    @options[:dsn]      = ENV['DSN'] if ENV['DSN']
+    @options[:dsn]      = 'ODBCAdapterPostgreSQLTest' if @options.values_at(:conn_str, :dsn).compact.empty?
+
+    ConnectionsTestDummyActiveRecordModel.establish_connection @options
+
+    @connection = ConnectionsTestDummyActiveRecordModel.connection
+  end
+
+  def teardown
+    @connection.disconnect!
+  end
+
+  def test_active?
+    assert_equal @connection.raw_connection.connected?, @connection.active?
+  end
+
+  def test_disconnect!
+    @raw_connection = @connection.raw_connection
+
+    assert_equal true, @raw_connection.connected?
+    @connection.disconnect!
+    assert_equal false, @raw_connection.connected?
+  end
+
+  def test_reconnect!
+    @old_raw_connection = @connection.raw_connection
+    assert_equal true, @connection.active?
+    @connection.reconnect!
+    refute_equal @old_raw_connection, @connection.raw_connection
+  end
+end


### PR DESCRIPTION
The `#reconnect!` method didn't work because the configuration wasn't kept in the adapter instance. This kept the method from actually being able to rebuild a connection.

Also, while I was in here, I made Travis work again after their recent changes and added a test for the connection methods that are implemented.

I have another PR incoming for backporting the v5.x `NullODBCAdapter`, so don't bump any version numbers just yet :)