### PR TITLE
upgrade to AR 5.2.1 and arel 9.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '5.0.1'
+gem 'activerecord', '>= 5.2.1'
 gem 'pry', '~> 0.11.1'

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -1,5 +1,5 @@
 require 'active_record'
-require 'arel/visitors/bind_visitor'
+require 'arel/visitors/visitor'
 require 'odbc'
 
 require 'odbc_adapter/database_limits'

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.3'.freeze
+  VERSION = '5.0.4'.freeze
 end


### PR DESCRIPTION
The newer versions of arel no longer have `arel/visitors/bind_visitor`. Need to `require 'arel/visitors/visitor'` instead. 