### PR TITLE
Reenable Rubocop, add encoding config parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  TargetRubyVersion: 2.1
   Exclude:
   - 'vendor/**/*'
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,6 @@ Rake::TestTask.new(:test) do |t|
 end
 
 RuboCop::RakeTask.new(:rubocop)
-# Temporarily removing as a prereq to get tests back up and working
-# Rake::Task[:test].prerequisites << :rubocop
+Rake::Task[:test].prerequisites << :rubocop
 
 task default: :test

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo "Testing mysql" && CONN_STR='DRIVER=MySQL;SERVER=localhost;DATABASE=odbc_test;USER=root;PASSWORD=;' bundle exec rake && \
-  echo "Testing postgres" && CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;' bundle exec rake
+  echo "Testing postgres" && CONN_STR='DRIVER={PostgreSQL ANSI};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;' bundle exec rake && \
+  echo "Testing postgres utf8" && CONN_STR='DRIVER={PostgreSQL UNICODE};SERVER=localhost;PORT=5432;DATABASE=odbc_test;UID=postgres;ENCODING=utf8' bundle exec rake

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -44,6 +44,7 @@ module ActiveRecord
         odbc_module = config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
         connection = odbc_module.connect(config[:dsn], username, password)
 
+        # encoding_bug indicates that the driver is using non ASCII and has the issue referenced here https://github.com/larskanis/ruby-odbc/issues/2
         [connection, config.merge(username: username, password: password, encoding_bug: config[:encoding] == 'utf8')]
       end
 
@@ -59,6 +60,7 @@ module ActiveRecord
         driver.attrs = attrs
 
         connection = odbc_module::Database.new.drvconnect(driver)
+        # encoding_bug indicates that the driver is using non ASCII and has the issue referenced here https://github.com/larskanis/ruby-odbc/issues/2
         [connection, config.merge(driver: driver, encoding: attrs['ENCODING'], encoding_bug: attrs['ENCODING'] == 'utf8')]
       end
     end

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       #      "DRIVER={OpenLink Virtuoso};HOST=carlmbp;UID=rails;PWD=rails"
       def odbc_conn_str_connection(config)
         attrs = config[:conn_str].split(';').map { |option| option.split('=', 2) }.to_h
-        odbc_module = attrs['Encoding'] == 'utf8' ? ODBC_UTF8 : ODBC
+        odbc_module = attrs['ENCODING'] == 'utf8' ? ODBC_UTF8 : ODBC
         driver = odbc_module::Driver.new
         driver.name = 'odbc'
         driver.attrs = attrs

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -31,7 +31,7 @@ module ActiveRecord
             raise ArgumentError, 'No data source name (:dsn) or connection string (:conn_str) specified.'
           end
 
-        database_metadata = ::ODBCAdapter::DatabaseMetadata.new(connection)
+        database_metadata = ::ODBCAdapter::DatabaseMetadata.new(connection, config[:encoding_bug])
         database_metadata.adapter_class.new(connection, logger, config, database_metadata)
       end
 
@@ -44,7 +44,7 @@ module ActiveRecord
         odbc_module = config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
         connection = odbc_module.connect(config[:dsn], username, password)
 
-        [connection, config.merge(username: username, password: password)]
+        [connection, config.merge(username: username, password: password, encoding_bug: config[:encoding] == 'utf8')]
       end
 
       # Connect using ODBC connection string
@@ -59,7 +59,7 @@ module ActiveRecord
         driver.attrs = attrs
 
         connection = odbc_module::Database.new.drvconnect(driver)
-        [connection, config.merge(driver: driver, encoding: attrs['Encoding'])]
+        [connection, config.merge(driver: driver, encoding: attrs['ENCODING'], encoding_bug: attrs['ENCODING'] == 'utf8')]
       end
     end
   end

--- a/lib/odbc_adapter/database_metadata.rb
+++ b/lib/odbc_adapter/database_metadata.rb
@@ -15,8 +15,14 @@ module ODBCAdapter
 
     attr_reader :values
 
-    def initialize(connection)
-      @values = Hash[FIELDS.map { |field| [field, connection.get_info(ODBC.const_get(field))] }]
+    def initialize(connection, has_encoding_bug = false)
+      puts "Encoding bug #{has_encoding_bug}"
+      @values = Hash[FIELDS.map do |field|
+        info = connection.get_info(ODBC.const_get(field))
+        info = info.bytes.each_with_index.flat_map { |c, idx| idx.even? ? [c] : [] }.pack('c*') if info.is_a?(String) && has_encoding_bug
+
+        [field, info]
+      end]
     end
 
     def adapter_class

--- a/lib/odbc_adapter/database_metadata.rb
+++ b/lib/odbc_adapter/database_metadata.rb
@@ -15,11 +15,12 @@ module ODBCAdapter
 
     attr_reader :values
 
+    # has_encoding_bug refers to https://github.com/larskanis/ruby-odbc/issues/2 where ruby-odbc in UTF8 mode
+    # returns incorrectly encoded responses to getInfo
     def initialize(connection, has_encoding_bug = false)
-      puts "Encoding bug #{has_encoding_bug}"
       @values = Hash[FIELDS.map do |field|
         info = connection.get_info(ODBC.const_get(field))
-        info = info.bytes.each_with_index.flat_map { |c, idx| idx.even? ? [c] : [] }.pack('c*') if info.is_a?(String) && has_encoding_bug
+        info = info.encode(Encoding.default_external, 'UTF-16LE') if info.is_a?(String) && has_encoding_bug
 
         [field, info]
       end]

--- a/lib/odbc_adapter/registry.rb
+++ b/lib/odbc_adapter/registry.rb
@@ -10,6 +10,8 @@ module ODBCAdapter
     end
 
     def adapter_for(reported_name)
+      puts reported_name.encoding
+      puts reported_name.bytes.inspect
       reported_name = reported_name.downcase.gsub(/\s/, '')
       found =
         dbs.detect do |pattern, adapter|

--- a/lib/odbc_adapter/registry.rb
+++ b/lib/odbc_adapter/registry.rb
@@ -10,8 +10,6 @@ module ODBCAdapter
     end
 
     def adapter_for(reported_name)
-      puts reported_name.encoding
-      puts reported_name.bytes.inspect
       reported_name = reported_name.downcase.gsub(/\s/, '')
       found =
         dbs.detect do |pattern, adapter|

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.3'.freeze
+  VERSION = '5.0.4'.freeze
 end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'minitest', '~> 5.10'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.48'
+  spec.add_development_dependency 'rubocop', '0.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.14'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
       { first_name: 'Jason', last_name: 'Dsouza', letters: 11 },
       { first_name: 'Ash', last_name: 'Hepburn', letters: 10 },
       { first_name: 'Sharif', last_name: 'Younes', letters: 12 },
-      { first_name: 'Ryan', last_name: 'Brown', letters: 9 }
+      { first_name: 'Ryan', last_name: 'Brüwn', letters: 9 }
     ]
   )
 end


### PR DESCRIPTION
This:
- puts rubocop back on the version that this was developed against (Thanks Chris)
- introduces a new config variable for connection strings and database.ymls called "encoding" that allows a user to switch to utf8