### PR TITLE
Handle connection failure by trying to reconnect and translating the error to ConnectionFailedError so the caller knows to retry

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,10 @@ FROM ruby:2.4.0
 MAINTAINER data@localytics.com
 
 ENV    DEBIAN_FRONTEND noninteractive
+RUN echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list
+RUN echo "deb-src http://deb.debian.org/debian/ jessie main" >> /etc/apt/sources.list
+RUN echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list
+RUN echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install libnss3-tools unixodbc-dev libmyodbc mysql-client odbc-postgresql  postgresql
 
 WORKDIR /workspace

--- a/lib/odbc_adapter/error.rb
+++ b/lib/odbc_adapter/error.rb
@@ -1,4 +1,6 @@
 module ODBCAdapter
   class QueryTimeoutError < ActiveRecord::StatementInvalid
   end
+  class ConnectionFailedError < ActiveRecord::StatementInvalid
+  end
 end

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.4'.freeze
+  VERSION = '5.0.5'.freeze
 end

--- a/test/connection_fail_test.rb
+++ b/test/connection_fail_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ConnectionFailTest < Minitest::Test
+  def test_connection_fail
+    # We're only interested in testing a MySQL connection failure for now.
+    # Postgres disconnects generate a different class of errors
+    skip 'Only executed for MySQL' unless ActiveRecord::Base.connection.instance_values['config'][:conn_str].include? 'MySQL'
+    begin
+      conn.execute('KILL CONNECTION_ID();')
+    rescue => e
+      puts "caught exception #{e}"
+    end
+    assert_raises(ODBCAdapter::ConnectionFailedError) { User.average(:letters).round(2) }
+  end
+
+  def conn
+    ActiveRecord::Base.connection
+  end
+end


### PR DESCRIPTION
When an ODBC connection failure occurs, try to reconnect at least once before bubbling up the exception to the application.  If we manage to reconnect, translate the error to a new ODBCAdapter:: ConnectionFailedError error so the ActiveRecord consumer can retry.