### PR TITLE
[MOJ-58] Limit db info to current schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   Exclude:
   - 'vendor/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'activerecord', '5.0.1'
-gem 'pry', '~> 0.11.1'

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'arel/visitors/bind_visitor'
 require 'odbc'
 require 'odbc_utf8'
 
@@ -75,6 +74,9 @@ module ActiveRecord
 
       ADAPTER_NAME = 'ODBC'.freeze
       BOOLEAN_TYPE = 'BOOLEAN'.freeze
+      VARIANT_TYPE = 'VARIANT'.freeze
+      DATE_TYPE = 'DATE'.freeze
+      JSON_TYPE = 'JSON'.freeze
 
       ERR_DUPLICATE_KEY_VALUE                     = 23_505
       ERR_QUERY_TIMED_OUT                         = 57_014
@@ -137,8 +139,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, table_name, default_function = nil, collation = nil, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, table_name, default_function, collation, native_type)
+      def new_column(name, default, sql_type_metadata, null, table_name, native_type = nil)
+        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, table_name, native_type)
       end
 
       protected
@@ -147,6 +149,7 @@ module ActiveRecord
       # Here, ODBC and ODBC_UTF8 constants are interchangeable
       def initialize_type_map(map)
         map.register_type 'boolean',              Type::Boolean.new
+        map.register_type 'json',                 Type::Json.new
         map.register_type ODBC::SQL_CHAR,         Type::String.new
         map.register_type ODBC::SQL_LONGVARCHAR,  Type::Text.new
         map.register_type ODBC::SQL_TINYINT,      Type::Integer.new(limit: 4)

--- a/lib/odbc_adapter/adapters/mysql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/mysql_odbc_adapter.rb
@@ -5,12 +5,8 @@ module ODBCAdapter
     class MySQLODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
       PRIMARY_KEY = 'INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY'.freeze
 
-      class BindSubstitution < Arel::Visitors::MySQL
-        include Arel::Visitors::BindVisitor
-      end
-
       def arel_visitor
-        BindSubstitution.new(self)
+        Arel::Visitors::MySQL.new(self)
       end
 
       # Explicitly turning off prepared statements in the MySQL adapter because

--- a/lib/odbc_adapter/adapters/null_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/null_odbc_adapter.rb
@@ -4,15 +4,14 @@ module ODBCAdapter
     # registry. This allows for minimal support for DBMSs for which we don't
     # have an explicit adapter.
     class NullODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
-      class BindSubstitution < Arel::Visitors::ToSql
-        include Arel::Visitors::BindVisitor
-      end
-
+      VARIANT_TYPE = 'VARIANT'.freeze
+      DATE_TYPE = 'DATE'.freeze
+      JSON_TYPE = 'JSON'.freeze
       # Using a BindVisitor so that the SQL string gets substituted before it is
       # sent to the DBMS (to attempt to get as much coverage as possible for
       # DBMSs we don't support).
       def arel_visitor
-        BindSubstitution.new(self)
+        Arel::Visitors::PostgreSQL.new(self)
       end
 
       # Explicitly turning off prepared_statements in the null adapter because

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -5,6 +5,9 @@ module ODBCAdapter
     class PostgreSQLODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
       BOOLEAN_TYPE = 'bool'.freeze
       PRIMARY_KEY  = 'SERIAL PRIMARY KEY'.freeze
+      VARIANT_TYPE = 'VARIANT'.freeze
+      DATE_TYPE = 'DATE'.freeze
+      JSON_TYPE = 'JSON'.freeze
 
       alias create insert
 
@@ -35,7 +38,7 @@ module ODBCAdapter
         "#{table_name}_#{pk || 'id'}_seq"
       end
 
-      def sql_for_insert(sql, pk, _id_value, _sequence_name, binds)
+      def sql_for_insert(sql, pk, binds)
         unless pk
           table_ref = extract_table_ref_from_insert_sql(sql)
           pk = primary_key(table_ref) if table_ref

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil)
-      super(name, default, sql_type_metadata, null, table_name)
+    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, **kwargs)
+      super(name, default, sql_type_metadata, null, table_name, kwargs)
       @native_type = native_type
     end
   end

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, default_function = nil, collation = nil)
-      super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil)
+      super(name, default, sql_type_metadata, null, table_name)
       @native_type = native_type
     end
   end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -15,8 +15,9 @@ module ODBCAdapter
       stmt.drop
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]) do |row, table_names|
-        next unless row[0] =~ db_regex
+        next unless row[0] =~ db_regex && row[1] =~ schema_regex
         schema_name, table_name, table_type = row[1..3]
         next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
         table_names << format_case(table_name)
@@ -39,8 +40,9 @@ module ODBCAdapter
       unique     = nil
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]).with_index do |(row, indices), row_idx|
-        next unless row[0] =~ db_regex
+        next unless row[0] =~ db_regex && row[1] =~ schema_regex
         # Skip table statistics
         next if row[6].zero? # SQLStatistics: TYPE
 
@@ -68,8 +70,9 @@ module ODBCAdapter
       stmt.drop
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]) do |col, cols|
-        next unless col[0] =~ db_regex
+        next unless col[0] =~ db_regex && row[1] =~ schema_regex
         col_name        = col[3]  # SQLColumns: COLUMN_NAME
         col_default     = col[12] # SQLColumns: COLUMN_DEF
         col_sql_type    = col[4]  # SQLColumns: DATA_TYPE
@@ -102,7 +105,8 @@ module ODBCAdapter
       stmt.drop unless stmt.nil?
 
       db_regex = /^#{current_database}$/i
-      result.reduce(nil) { |pkey, key| key[0] =~ db_regex ? key[3] : pkey }
+      schema_regex = /^#{current_schema}$/i
+      result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? key[3] : pkey }
     end
 
     def foreign_keys(table_name)
@@ -111,8 +115,9 @@ module ODBCAdapter
       stmt.drop unless stmt.nil?
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.map do |key|
-        next unless key[0] =~ db_regex
+        next unless key[0] =~ db_regex && key[1] =~ schema_regex
         fk_from_table      = key[2]  # PKTABLE_NAME
         fk_to_table        = key[6]  # FKTABLE_NAME
 
@@ -137,6 +142,10 @@ module ODBCAdapter
 
     def current_database
       database_metadata.database_name.strip
+    end
+
+    def current_schema
+      @config[:driver].attrs['schema']
     end
   end
 end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -76,6 +76,8 @@ module ODBCAdapter
 
         args = { sql_type: col_sql_type, type: col_sql_type, limit: col_limit }
         args[:sql_type] = 'boolean' if col_native_type == self.class::BOOLEAN_TYPE
+        args[:sql_type] = 'json' if col_native_type == self.class::VARIANT_TYPE || col_native_type == self.class::JSON_TYPE
+        args[:sql_type] = 'date' if col_native_type == self.class::DATE_TYPE
 
         if [ODBC::SQL_DECIMAL, ODBC::SQL_NUMERIC].include?(col_sql_type)
           args[:scale]     = col_scale || 0

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -14,7 +14,9 @@ module ODBCAdapter
       result = stmt.fetch_all || []
       stmt.drop
 
+      db_regex = /^#{current_database}$/i
       result.each_with_object([]) do |row, table_names|
+        next unless row[0] =~ db_regex
         schema_name, table_name, table_type = row[1..3]
         next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
         table_names << format_case(table_name)
@@ -36,7 +38,9 @@ module ODBCAdapter
       index_name = nil
       unique     = nil
 
+      db_regex = /^#{current_database}$/i
       result.each_with_object([]).with_index do |(row, indices), row_idx|
+        next unless row[0] =~ db_regex
         # Skip table statistics
         next if row[6].zero? # SQLStatistics: TYPE
 
@@ -63,7 +67,9 @@ module ODBCAdapter
       result = stmt.fetch_all || []
       stmt.drop
 
+      db_regex = /^#{current_database}$/i
       result.each_with_object([]) do |col, cols|
+        next unless col[0] =~ db_regex
         col_name        = col[3]  # SQLColumns: COLUMN_NAME
         col_default     = col[12] # SQLColumns: COLUMN_DEF
         col_sql_type    = col[4]  # SQLColumns: DATA_TYPE
@@ -94,7 +100,9 @@ module ODBCAdapter
       stmt   = @connection.primary_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
-      result[0] && result[0][3]
+
+      db_regex = /^#{current_database}$/i
+      result.reduce(nil) { |pkey, key| key[0] =~ db_regex ? key[3] : pkey }
     end
 
     def foreign_keys(table_name)
@@ -102,7 +110,9 @@ module ODBCAdapter
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
+      db_regex = /^#{current_database}$/i
       result.map do |key|
+        next unless key[0] =~ db_regex
         fk_from_table      = key[2]  # PKTABLE_NAME
         fk_to_table        = key[6]  # FKTABLE_NAME
 

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.5'.freeze
+  VERSION = '5.0.6'.freeze
 end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,11 +19,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activerecord', '>= 5.0.1'
   spec.add_dependency 'ruby-odbc', '~> 0.9'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'minitest', '~> 5.10'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '0.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.14'
+  spec.add_development_dependency 'pry', '~> 0.11.1'
 end


### PR DESCRIPTION
Problem: The SchemaStatements methods get tables from all schemas without identifying which schema each came from. This is a problem for migrations when multiple schemas are used.

Change: limit the SchemaStatements methods to return objects in the current schema only.