### PR TITLE
Fix column call

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'arel/visitors/bind_visitor'
 require 'odbc'
 require 'odbc_utf8'
 

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, default_function = nil, collation = nil)
-      super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+    def initialize(name, default, sql_type_metadata = nil, null = true, _table_name = nil, native_type = nil, default_function = nil, collation = nil)
+      super(name, default, sql_type_metadata, null, default_function, collation: collation)
       @native_type = native_type
     end
   end


### PR DESCRIPTION
Fixes a no-longer-valid call to a super method in the adapter

`wrong number of arguments (given 7, expected 2..5)` was possible when fetching metadata.